### PR TITLE
Fix user prefs not persisting on JVM

### DIFF
--- a/core/src/jvmMain/kotlin/com/ramitsuri/notificationjournal/core/di/Di.kt
+++ b/core/src/jvmMain/kotlin/com/ramitsuri/notificationjournal/core/di/Di.kt
@@ -13,17 +13,17 @@ import com.ramitsuri.notificationjournal.core.ui.editjournal.EditJournalEntryVie
 import com.ramitsuri.notificationjournal.core.utils.NotificationChannelInfo
 import com.ramitsuri.notificationjournal.core.utils.NotificationHandler
 import com.ramitsuri.notificationjournal.core.utils.NotificationInfo
-import com.russhwolf.settings.PropertiesSettings
+import com.russhwolf.settings.PreferencesSettings
 import com.russhwolf.settings.Settings
 import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
 import java.io.File
-import java.util.Properties
+import java.util.prefs.Preferences
 import kotlin.reflect.KClass
 
 actual class Factory {
     actual fun getSettings(): Settings {
-        return PropertiesSettings(Properties())
+        return PreferencesSettings(Preferences.userRoot().node("com.ramitsuri.notificationjournal"))
     }
 
     actual fun getDatabaseBuilder(): RoomDatabase.Builder<AppDatabase> {


### PR DESCRIPTION
Not sure what's the setup needed with Properties but that wasn't
working. Switched to using Preferences and the file seems to be
shared with other apps so put a rood node for my prefs.
The file is located at ~/Library/Preferences/com.apple.java.util.prefs.plist
on macos.
