### PR TITLE
Use different times when single entry is split

### DIFF
--- a/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/repository/JournalRepository.kt
+++ b/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/repository/JournalRepository.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.launch
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
+import kotlin.time.Duration.Companion.milliseconds
 
 class JournalRepository(
     private val coroutineScope: CoroutineScope,
@@ -41,16 +42,17 @@ class JournalRepository(
         originalEntryTime: Instant? = null,
         send: Boolean = true,
     ) {
-        val entryTime = clock.now()
+        val now = clock.now()
         text
             .split("\n")
             .filter { it.isNotBlank() }
-            .forEach {
+            .forEachIndexed { index, entry ->
+                val entryTime = now.plus(index.times(10).milliseconds)
                 insert(
                     entry = JournalEntry(
                         entryTime = entryTime,
                         timeZone = timeZone,
-                        text = it.trim(),
+                        text = entry.trim(),
                         tag = tag,
                         entryTimeOverride = originalEntryTime
                     ),

--- a/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/ui/journalentry/JournalEntryViewModel.kt
+++ b/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/ui/journalentry/JournalEntryViewModel.kt
@@ -25,7 +25,7 @@ import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
 import kotlin.reflect.KClass
 import kotlin.time.Duration.Companion.days
-import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Duration.Companion.milliseconds
 
 class JournalEntryViewModel(
     receivedText: String?,
@@ -109,7 +109,7 @@ class JournalEntryViewModel(
             return
         }
         val nextEntry = tagGroup.entries[indexOfEntry + 1]
-        val newDateTime = (nextEntry.entryTimeOverride ?: nextEntry.entryTime).plus(1.seconds)
+        val newDateTime = (nextEntry.entryTimeOverride ?: nextEntry.entryTime).plus(1.milliseconds)
         setDate(journalEntry, newDateTime)
     }
 
@@ -121,7 +121,7 @@ class JournalEntryViewModel(
         }
         val previousEntry = tagGroup.entries[indexOfEntry - 1]
         val newDateTime =
-            (previousEntry.entryTimeOverride ?: previousEntry.entryTime).minus(1.seconds)
+            (previousEntry.entryTimeOverride ?: previousEntry.entryTime).minus(1.milliseconds)
         setDate(journalEntry, newDateTime)
     }
 


### PR DESCRIPTION
Using different times for entries when splitting a single entry so
that moving entries up and down in the list doesn't move them across
all the entries that were added together.
