### PR TITLE
Fix entries not marked not uploaded

### DIFF
--- a/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/data/JournalEntryDao.kt
+++ b/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/data/JournalEntryDao.kt
@@ -39,10 +39,10 @@ abstract class JournalEntryDao {
     }
 
     @Transaction
-    open suspend fun updateUploaded(entries: List<JournalEntry>) {
+    open suspend fun updateUploaded(entries: List<JournalEntry>, uploaded: Boolean) {
         entries
             .forEach {
-                update(it.copy(uploaded = true))
+                update(it.copy(uploaded = uploaded))
             }
     }
 

--- a/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/repository/JournalRepository.kt
+++ b/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/repository/JournalRepository.kt
@@ -95,9 +95,7 @@ class JournalRepository(
     private fun sendAndMarkUploaded(entries: List<JournalEntry>) {
         coroutineScope.launch {
             val sent = dataSendHelper?.sendEntry(entries) == true
-            if (sent) {
-                dao.updateUploaded(entries)
-            }
+            dao.updateUploaded(entries = entries, uploaded = sent)
         }
     }
 }


### PR DESCRIPTION
There were two bugs when editing entries but connection wasn't
available

- entries were only being marked as true when updates were made.
- when connection isn't available, closing the connection was
causing a deadlock so the entry would not get uploaded at all
