### PR TITLE
Upload only when requested

### DIFF
--- a/app/src/main/java/com/ramitsuri/notificationjournal/broadcast/NotificationActionReceiver.kt
+++ b/app/src/main/java/com/ramitsuri/notificationjournal/broadcast/NotificationActionReceiver.kt
@@ -35,9 +35,7 @@ class NotificationActionReceiver : BroadcastReceiver() {
         val pendingResult = goAsync()
         val repository = ServiceLocator.repository
         ServiceLocator.coroutineScope.launch {
-            // Because app is probably in background at this time, so we can't use too many
-            // resources
-            repository.insert(text = text, send = false)
+            repository.insert(text = text)
             pendingResult.finish()
         }
         (context.applicationContext as MainApplication).showJournalNotification()

--- a/app/src/main/java/com/ramitsuri/notificationjournal/service/PhoneDataLayerListenerService.kt
+++ b/app/src/main/java/com/ramitsuri/notificationjournal/service/PhoneDataLayerListenerService.kt
@@ -62,7 +62,7 @@ class PhoneDataLayerListenerService : WearableListenerService() {
 
                 val repository = ServiceLocator.repository
                 ServiceLocator.coroutineScope.launch {
-                    repository.insert(entry = journalEntry, send = false)
+                    repository.insert(entry = journalEntry)
                 }
             }
         }

--- a/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/repository/JournalRepository.kt
+++ b/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/repository/JournalRepository.kt
@@ -38,8 +38,7 @@ class JournalRepository(
     }
 
     suspend fun update(journalEntry: JournalEntry) {
-        val updated = dao.update(journalEntry)
-        sendAndMarkUploaded(listOf(updated))
+        dao.update(journalEntry.copy(uploaded = false))
     }
 
     suspend fun insert(
@@ -47,7 +46,6 @@ class JournalRepository(
         tag: String? = null,
         time: Instant = clock.now(),
         originalEntryTime: Instant? = null,
-        send: Boolean = true,
     ) {
         text
             .split("\n")
@@ -62,24 +60,18 @@ class JournalRepository(
                         tag = tag,
                         entryTimeOverride = originalEntryTime
                     ),
-                    send = send,
                 )
             }
     }
 
     suspend fun insert(
         entry: JournalEntry,
-        send: Boolean = true,
     ) {
-        val inserted = dao.insert(entry)
-        if (send) {
-            sendAndMarkUploaded(listOf(inserted))
-        }
+        dao.insert(entry)
     }
 
     suspend fun delete(entry: JournalEntry) {
-        val deleted = dao.update(entry.copy(deleted = true))
-        sendAndMarkUploaded(listOf(deleted))
+        dao.update(entry.copy(deleted = true, uploaded = false))
     }
 
     suspend fun sync() {

--- a/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/ui/journalentry/JournalEntryScreen.kt
+++ b/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/ui/journalentry/JournalEntryScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Sync
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Badge
 import androidx.compose.material3.Card
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -259,7 +260,7 @@ fun JournalEntryScreen(
                 )
 
                 Toolbar(
-                    showSyncButton = state.showSyncButton,
+                    notUploadedCount = state.notUploadedCount,
                     onSyncClicked = onSyncClicked,
                     onSettingsClicked = onSettingsClicked
                 )
@@ -315,22 +316,30 @@ fun JournalEntryScreen(
 
 @Composable
 private fun Toolbar(
-    showSyncButton: Boolean,
+    notUploadedCount: Int,
     onSyncClicked: () -> Unit,
     onSettingsClicked: () -> Unit,
 ) {
     Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
-        if (showSyncButton) {
-            IconButton(
-                onClick = onSyncClicked,
-                modifier = Modifier
-                    .size(48.dp)
-                    .padding(4.dp)
-            ) {
-                Icon(
-                    imageVector = Icons.Filled.Sync,
-                    contentDescription = stringResource(Res.string.settings_upload_title)
-                )
+        Box(
+            modifier = Modifier
+                .size(48.dp)
+                .padding(4.dp)
+                .clickable(onClick = onSyncClicked),
+        ) {
+            Icon(
+                imageVector = Icons.Filled.Sync,
+                contentDescription = stringResource(Res.string.settings_upload_title),
+                modifier = Modifier.align(Alignment.Center)
+            )
+            if (notUploadedCount > 0) {
+                Badge(
+                    containerColor = MaterialTheme.colorScheme.background,
+                    contentColor = MaterialTheme.colorScheme.onBackground,
+                    modifier = Modifier.align(Alignment.BottomEnd)
+                ) {
+                    Text("$notUploadedCount")
+                }
             }
         }
         IconButton(

--- a/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/ui/journalentry/JournalEntryViewModel.kt
+++ b/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/ui/journalentry/JournalEntryViewModel.kt
@@ -198,7 +198,7 @@ class JournalEntryViewModel(
                         previousState.copy(
                             dayGroups = sorted,
                             tags = tags,
-                            showSyncButton = forUploadCount > 0
+                            notUploadedCount = forUploadCount
                         )
                     }
                 }
@@ -225,5 +225,5 @@ data class ViewState(
     val dayGroups: List<DayGroup> = listOf(),
     val tags: List<Tag>,
     val loading: Boolean = false,
-    val showSyncButton: Boolean = false,
+    val notUploadedCount: Int = 0,
 )


### PR DESCRIPTION
Rather than uploading at all times, going to upload now only when
requested so that there's only one upload for any entry at any point
of time. This is to avoid the issue where some entries are probably
getting overwritten due to the order they come in. If this works,
then it should also avoid having to implement verification via
other devices
