### PR TITLE
Allow day copy + other fixes

### DIFF
--- a/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/data/JournalEntryDao.kt
+++ b/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/data/JournalEntryDao.kt
@@ -35,16 +35,13 @@ abstract class JournalEntryDao {
     }
 
     @Transaction
-    open suspend fun update(entry: JournalEntry) {
-        updateInternal(entry)
+    open suspend fun update(entries: List<JournalEntry>) {
+        updateInternal(entries)
     }
 
     @Transaction
     open suspend fun updateUploaded(entries: List<JournalEntry>, uploaded: Boolean) {
-        entries
-            .forEach {
-                update(it.copy(uploaded = uploaded))
-            }
+        update(entries.map { it.copy(uploaded = uploaded) })
     }
 
     @Upsert
@@ -54,5 +51,5 @@ abstract class JournalEntryDao {
     protected abstract suspend fun insertInternal(journalEntry: JournalEntry)
 
     @Update
-    protected abstract suspend fun updateInternal(journalEntry: JournalEntry)
+    protected abstract suspend fun updateInternal(journalEntries: List<JournalEntry>)
 }

--- a/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/repository/JournalRepository.kt
+++ b/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/repository/JournalRepository.kt
@@ -48,7 +48,11 @@ class JournalRepository(
     }
 
     suspend fun update(journalEntry: JournalEntry) {
-        dao.update(journalEntry.copy(uploaded = false))
+        update(listOf(journalEntry))
+    }
+
+    suspend fun update(journalEntries: List<JournalEntry>) {
+        dao.update(journalEntries.map { it.copy(uploaded = false) })
     }
 
     suspend fun insert(
@@ -87,7 +91,11 @@ class JournalRepository(
     }
 
     suspend fun delete(entry: JournalEntry) {
-        dao.update(entry.copy(deleted = true, uploaded = false))
+        delete(listOf(entry))
+    }
+
+    suspend fun delete(entries: List<JournalEntry>) {
+        update(entries.map { it.copy(deleted = true) })
     }
 
     suspend fun sync() {

--- a/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/ui/nav/Navigation.kt
+++ b/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/ui/nav/Navigation.kt
@@ -133,6 +133,11 @@ fun NavGraph(
                 onShowPreviousDayClicked = viewModel::goToPreviousDay,
                 onShowNextDayClicked = viewModel::goToNextDay,
                 onShowDayGroupClicked = viewModel::showDayGroupClicked,
+                onDayGroupReconcileRequested = viewModel::reconcile,
+                onCopyEntryRequested = viewModel::onCopy,
+                onCopyTagGroupRequested = viewModel::onCopy,
+                onCopyDayGroupRequested = viewModel::onCopy,
+                onCopied = viewModel::onContentCopied,
             )
         }
 

--- a/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/utils/DateTimeHelper.kt
+++ b/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/utils/DateTimeHelper.kt
@@ -24,6 +24,7 @@ import notificationjournal.core.generated.resources.pm
 import notificationjournal.core.generated.resources.today
 import notificationjournal.core.generated.resources.tomorrow
 import notificationjournal.core.generated.resources.yesterday
+import org.jetbrains.compose.resources.getStringArray
 import org.jetbrains.compose.resources.stringArrayResource
 import org.jetbrains.compose.resources.stringResource
 
@@ -132,4 +133,22 @@ fun getLocalDate(
     zoneId: TimeZone = TimeZone.currentSystemDefault(),
 ): LocalDate {
     return time.toLocalDateTime(zoneId).date
+}
+
+// Saturday, November 16 2024
+suspend fun dayMonthDateWithYear(
+    toFormat: LocalDate,
+): String {
+    val monthNames = getStringArray(Res.array.month_names)
+    val dayOfWeekNames = getStringArray(Res.array.day_of_week_names)
+    return LocalDate.Format {
+        dayOfWeek(DayOfWeekNames(dayOfWeekNames))
+        char(',')
+        char(' ')
+        monthName(MonthNames(monthNames))
+        char(' ')
+        dayOfMonth()
+        char(' ')
+        year()
+    }.format(toFormat)
 }


### PR DESCRIPTION
Allows copying full day with formatting needed to paste it in
markdown format
On desktop app, adjusts size on every onResume because of the
issue where dialogs don't open in the center but do after resize
Fix a crash when there's no entry and an entry is added
Fix issue where comma was being shown if no untagged entries
but conflicts were there
