### PR TITLE
Change various things

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -122,6 +122,8 @@ compose.desktop {
             macOS {
                 iconFile.set(iconsRoot.resolve("macos.icns"))
             }
+            // https://issuetracker.google.com/issues/342609814
+            modules("jdk.unsupported")
         }
     }
 }

--- a/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/di/ServiceLocator.kt
+++ b/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/di/ServiceLocator.kt
@@ -139,6 +139,7 @@ object ServiceLocator {
             savedStateHandle = savedStateHandle,
             repository = repository,
             tagsDao = tagsDao,
+            templatesDao = templatesDao,
         )
     }
 

--- a/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/model/template/JournalEntryTemplate.kt
+++ b/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/model/template/JournalEntryTemplate.kt
@@ -4,6 +4,8 @@ import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.Ignore
 import androidx.room.PrimaryKey
+import com.ramitsuri.notificationjournal.core.model.Tag
+import com.ramitsuri.notificationjournal.core.utils.Constants
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import java.util.UUID
@@ -50,3 +52,20 @@ data class JournalEntryTemplate(
         replacesExistingValues = true,
     )
 }
+
+fun JournalEntryTemplate.Companion.getShortcutTemplates() = listOf(
+    JournalEntryTemplate(
+        text = " ${Constants.TEMPLATED_TIME}",
+        displayText = "Time",
+        shortDisplayText = "\uD83D\uDD5B",
+        tag = Tag.NO_TAG.value,
+        replacesExistingValues = false,
+    ),
+    JournalEntryTemplate(
+        text = "${Constants.TEMPLATED_TASK} ",
+        displayText = "Task",
+        shortDisplayText = "\uD83D\uDCDD",
+        tag = Tag.NO_TAG.value,
+        replacesExistingValues = false,
+    ),
+)

--- a/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/ui/addjournal/AddJournalEntryViewModel.kt
+++ b/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/ui/addjournal/AddJournalEntryViewModel.kt
@@ -7,8 +7,8 @@ import com.ramitsuri.notificationjournal.core.data.JournalEntryTemplateDao
 import com.ramitsuri.notificationjournal.core.data.TagsDao
 import com.ramitsuri.notificationjournal.core.model.Tag
 import com.ramitsuri.notificationjournal.core.model.template.JournalEntryTemplate
+import com.ramitsuri.notificationjournal.core.model.template.getShortcutTemplates
 import com.ramitsuri.notificationjournal.core.repository.JournalRepository
-import com.ramitsuri.notificationjournal.core.utils.Constants
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
@@ -197,7 +197,10 @@ class AddJournalEntryViewModel(
     private fun loadTemplates() {
         viewModelScope.launch {
             _state.update {
-                it.copy(templates = templatesDao.getAll().plus(getShortcutTemplates()))
+                it.copy(
+                    templates = templatesDao.getAll()
+                        .plus(JournalEntryTemplate.getShortcutTemplates())
+                )
             }
         }
     }
@@ -211,16 +214,6 @@ class AddJournalEntryViewModel(
             }
         }
     }
-
-    private fun getShortcutTemplates() = listOf(
-        JournalEntryTemplate(
-            text = " ${Constants.TEMPLATED_TIME}",
-            displayText = "Time",
-            shortDisplayText = "\uD83D\uDD5B",
-            tag = Tag.NO_TAG.value,
-            replacesExistingValues = false,
-        )
-    )
 
     companion object {
         const val RECEIVED_TEXT_ARG = "received_text"

--- a/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/ui/editjournal/EditJournalEntryScreen.kt
+++ b/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/ui/editjournal/EditJournalEntryScreen.kt
@@ -1,6 +1,7 @@
 package com.ramitsuri.notificationjournal.core.ui.editjournal
 
 import androidx.compose.runtime.Composable
+import com.ramitsuri.notificationjournal.core.model.template.JournalEntryTemplate
 import com.ramitsuri.notificationjournal.core.ui.components.AddEditEntryDialog
 
 @Composable
@@ -8,6 +9,7 @@ fun EditJournalEntryScreen(
     state: EditJournalEntryViewState,
     onTextUpdated: (String) -> Unit,
     onTagClicked: (String) -> Unit,
+    onTemplateClicked: (JournalEntryTemplate) -> Unit,
     onSave: () -> Unit,
     onCancel: () -> Unit,
     onPreviousDateRequested: () -> Unit,
@@ -22,11 +24,11 @@ fun EditJournalEntryScreen(
         tags = state.tags,
         selectedTag = state.selectedTag,
         suggestedText = state.suggestedText,
-        templates = listOf(),
+        templates = state.templates,
         dateTime = state.localDateTime,
         onTextUpdated = onTextUpdated,
         onTagClicked = onTagClicked,
-        onTemplateClicked = { },
+        onTemplateClicked = onTemplateClicked,
         onUseSuggestedText = { },
         onSave = onSave,
         showAddAnother = false,

--- a/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/ui/journalentry/JournalEntryScreen.kt
+++ b/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/ui/journalentry/JournalEntryScreen.kt
@@ -150,7 +150,6 @@ import notificationjournal.core.generated.resources.next_day
 import notificationjournal.core.generated.resources.no_items
 import notificationjournal.core.generated.resources.ok
 import notificationjournal.core.generated.resources.previous_day
-import notificationjournal.core.generated.resources.reconcile
 import notificationjournal.core.generated.resources.settings
 import notificationjournal.core.generated.resources.untagged
 import notificationjournal.core.generated.resources.untagged_format
@@ -177,7 +176,6 @@ fun JournalEntryScreen(
     onTagGroupMoveToNextDayRequested: (TagGroup) -> Unit,
     onTagGroupMoveToPreviousDayRequested: (TagGroup) -> Unit,
     onTagGroupDeleteRequested: (TagGroup) -> Unit,
-    onTagGroupReconcileRequested: (TagGroup) -> Unit,
     onTagGroupForceUploadRequested: (TagGroup) -> Unit,
     onSettingsClicked: () -> Unit,
     onConflictResolved: (JournalEntry, EntryConflict?) -> Unit,
@@ -384,7 +382,6 @@ fun JournalEntryScreen(
                     },
                     onTagGroupMoveToNextDayRequested = onTagGroupMoveToNextDayRequested,
                     onTagGroupMoveToPreviousDayRequested = onTagGroupMoveToPreviousDayRequested,
-                    onTagGroupReconcileRequested = onTagGroupReconcileRequested,
                     onTagGroupForceUploadRequested = onTagGroupForceUploadRequested,
                     onForceUploadRequested = onForceUploadRequested,
                     onDuplicateRequested = onDuplicateRequested,
@@ -474,7 +471,6 @@ private fun List(
     onTagGroupDeleteRequested: (TagGroup) -> Unit,
     onTagGroupMoveToNextDayRequested: (TagGroup) -> Unit,
     onTagGroupMoveToPreviousDayRequested: (TagGroup) -> Unit,
-    onTagGroupReconcileRequested: (TagGroup) -> Unit,
     onTagGroupForceUploadRequested: (TagGroup) -> Unit,
     onMoveUpRequested: (JournalEntry, TagGroup) -> Unit,
     onMoveToTopRequested: (JournalEntry, TagGroup) -> Unit,
@@ -528,9 +524,9 @@ private fun List(
                             return@detectHorizontalDragGestures
                         }
                         if (swipeAmount > 0) {
-                            onShowNextDay()
-                        } else {
                             onShowPreviousDay()
+                        } else {
+                            onShowNextDay()
                         }
                         swipeAmount = 0f
                     },
@@ -555,7 +551,6 @@ private fun List(
                         onDeleteRequested = onTagGroupDeleteRequested,
                         onMoveToNextDayRequested = onTagGroupMoveToNextDayRequested,
                         onMoveToPreviousDayRequested = onTagGroupMoveToPreviousDayRequested,
-                        onReconcileRequested = onTagGroupReconcileRequested,
                         onForceUploadRequested = onTagGroupForceUploadRequested,
                         modifier = Modifier
                             .fillMaxWidth()
@@ -761,7 +756,6 @@ private fun SubHeaderItem(
     onDeleteRequested: (TagGroup) -> Unit,
     onMoveToNextDayRequested: (TagGroup) -> Unit,
     onMoveToPreviousDayRequested: (TagGroup) -> Unit,
-    onReconcileRequested: (TagGroup) -> Unit,
     onForceUploadRequested: (TagGroup) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -789,7 +783,6 @@ private fun SubHeaderItem(
                 onMenuButtonClicked = { showMenu = !showMenu },
                 onMoveToNextDayRequested = { onMoveToNextDayRequested(tagGroup) },
                 onMoveToPreviousDayRequested = { onMoveToPreviousDayRequested(tagGroup) },
-                onReconcileRequested = { onReconcileRequested(tagGroup) },
                 onForceUploadRequested = { onForceUploadRequested(tagGroup) }
             )
         }
@@ -1390,7 +1383,6 @@ private fun SubHeaderItemMenu(
     onMenuButtonClicked: () -> Unit,
     onMoveToNextDayRequested: () -> Unit,
     onMoveToPreviousDayRequested: () -> Unit,
-    onReconcileRequested: () -> Unit,
     onForceUploadRequested: () -> Unit
 ) {
     var showingMoreMenu by remember { mutableStateOf(false) }
@@ -1415,11 +1407,10 @@ private fun SubHeaderItemMenu(
         ) {
             if (showingMoreMenu.not()) {
                 DropdownMenuItem(
-                    text = { Text(stringResource(Res.string.copy_reconcile)) },
+                    text = { Text(stringResource(Res.string.copy)) },
                     onClick = {
                         onMenuButtonClicked()
                         onCopyRequested()
-                        onReconcileRequested()
                     }
                 )
                 DropdownMenuItem(
@@ -1441,20 +1432,6 @@ private fun SubHeaderItemMenu(
                     onClick = {
                         onMenuButtonClicked()
                         onMoveToPreviousDayRequested()
-                    }
-                )
-                DropdownMenuItem(
-                    text = { Text(stringResource(Res.string.copy)) },
-                    onClick = {
-                        onMenuButtonClicked()
-                        onCopyRequested()
-                    }
-                )
-                DropdownMenuItem(
-                    text = { Text(stringResource(Res.string.reconcile)) },
-                    onClick = {
-                        onMenuButtonClicked()
-                        onReconcileRequested()
                     }
                 )
                 DropdownMenuItem(

--- a/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/ui/journalentry/JournalEntryViewModel.kt
+++ b/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/ui/journalentry/JournalEntryViewModel.kt
@@ -221,14 +221,6 @@ class JournalEntryViewModel(
         }
     }
 
-    fun reconcile(tagGroup: TagGroup) {
-        viewModelScope.launch {
-            tagGroup.entries.forEach { journalEntry ->
-                repository.update(journalEntry.copy(reconciled = true))
-            }
-        }
-    }
-
     fun reconcile() {
         val dayGroup = state.value.selectedDayGroup
         viewModelScope.launch {
@@ -310,6 +302,9 @@ class JournalEntryViewModel(
     fun onCopy() {
         val dayGroup = state.value.selectedDayGroup
         if (dayGroup.untaggedCount > 0) {
+            return
+        }
+        if ((state.value.dayGroupConflictCountMap[dayGroup] ?: 0) > 0) {
             return
         }
         viewModelScope.launch(Dispatchers.Default) {

--- a/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/ui/nav/Navigation.kt
+++ b/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/ui/nav/Navigation.kt
@@ -119,7 +119,6 @@ fun NavGraph(
                     navController.navigate(Destination.SETTINGS.routeWithArgValues())
                 },
                 onSyncClicked = viewModel::sync,
-                onTagGroupReconcileRequested = viewModel::reconcile,
                 onTagGroupForceUploadRequested = viewModel::forceUpload,
                 onForceUploadRequested = viewModel::forceUpload,
                 onConflictResolved = viewModel::resolveConflict,
@@ -194,6 +193,7 @@ fun NavGraph(
                 state = viewState,
                 onTextUpdated = viewModel::textUpdated,
                 onTagClicked = viewModel::tagClicked,
+                onTemplateClicked = viewModel::templateClicked,
                 onSave = viewModel::save,
                 onCancel = { navController.navigateUp() },
                 onPreviousDateRequested = viewModel::previousDay,

--- a/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/utils/Constants.kt
+++ b/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/utils/Constants.kt
@@ -3,7 +3,8 @@ package com.ramitsuri.notificationjournal.core.utils
 object Constants {
     const val REMOTE_INPUT_JOURNAL_KEY = "remote_input_journal_text"
     const val ACTION_JOURNAL = "action_journal"
-    const val TEMPLATED_TIME = "{{hh:mm aa}}"
+    const val TEMPLATED_TIME = "{{time}}"
+    const val TEMPLATED_TASK = "[ ]"
 
     const val PREF_FILE = "com.ramitsuri.notificationjournal.prefs"
     const val PREF_KEY_DATA_HOST = "data_host"


### PR DESCRIPTION
- Fix datastore not working on JVM
- Allow templates when editing entries
- Find templated time when editing entries
- Fix next day previous day swipe
- Remove copy and reconcile option from tag groups and move copy up to first menu
- Disallow day copy if conflicts
- Allow templates with no tag
- Add shortcut template for task
