### PR TITLE
Add desktop build and install script

### DIFF
--- a/scripts/build-desktop.sh
+++ b/scripts/build-desktop.sh
@@ -1,0 +1,10 @@
+# Make not debug
+sed -i '' "s/isDebug=true/isDebug=false/g" ./local.properties
+
+./gradlew clean
+./gradlew packageDistributionForCurrentOS
+
+# Make debug version again
+sed -i '' "s/isDebug=false/isDebug=true/g" ./local.properties
+
+open ./core/build/compose/binaries/main/dmg/Journal-1.0.0.dmg


### PR DESCRIPTION
Because if built on another computer, there's a security thing shown
making it harder to install the app. Stop gap until I figure out a
better solution
