### PR TITLE
Fix template related things

### DIFF
--- a/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/ui/addjournal/AddJournalEntryViewModel.kt
+++ b/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/ui/addjournal/AddJournalEntryViewModel.kt
@@ -94,6 +94,12 @@ class AddJournalEntryViewModel(
     }
 
     fun templateClicked(template: JournalEntryTemplate) {
+        // When entry is added by tapping the add button at the bottom of a tag, the time is derived
+        // from the last entry in that tag but when adding via template, it's most likely not the
+        // intention to use that time. So reset it.
+        _state.update {
+            it.copy(dateTime = it.dateTime.date.atTime(clock.nowLocal().time))
+        }
         _state.value.textFieldState.edit {
             if (template.replacesExistingValues) {
                 tagClicked(template.tag)

--- a/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/ui/components/AddEditEntryDialog.kt
+++ b/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/ui/components/AddEditEntryDialog.kt
@@ -1011,7 +1011,7 @@ private fun Templates(
                         selected = false,
                         onClick = { onTemplateClicked(template) },
                         label = {
-                            Text(text = template.displayText)
+                            Text(text = "${template.shortDisplayText} ${template.displayText}")
                         })
 
                     val hint = if (index == 9) {


### PR DESCRIPTION
- time is used from last entry in the tag when using the add button
at the bottom of the tag but with templates, that's most likely
not the intention so when template is tapped, resetting time.
- showing short display text of template in the add/edit view to
make it easier to find which template is which
