### PR TITLE
Fix default last import date causing a crash

### DIFF
--- a/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/ui/import/ImportViewModel.kt
+++ b/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/ui/import/ImportViewModel.kt
@@ -35,6 +35,7 @@ class ImportViewModel(
         ViewState(
             startDate = defaultStartDate,
             endDate = defaultEndDate,
+            lastImportDate = defaultLastImportDate,
         )
     )
     val state = _state.asStateFlow()
@@ -45,8 +46,11 @@ class ImportViewModel(
                 _state.update {
                     it.copy(
                         fromDir = prefManager.getLastImportDir().first(),
-                        lastImportDate = prefManager.getLastImportDate().first()
-                            .toLocalDateTime(timeZone).date,
+                        lastImportDate = prefManager
+                            .getLastImportDate()
+                            .first()
+                            ?.fromInstant()
+                            ?: defaultLastImportDate,
                     )
                 }
             }
@@ -132,7 +136,11 @@ class ImportViewModel(
         viewModelScope.launch {
             _state.update {
                 it.copy(
-                    lastImportDate = prefManager.getLastImportDate().first().fromInstant(),
+                    lastImportDate = prefManager
+                        .getLastImportDate()
+                        .first()
+                        ?.fromInstant()
+                        ?: defaultLastImportDate,
                 )
             }
         }
@@ -151,6 +159,8 @@ class ImportViewModel(
             get() = Constants.LocalDate.IMPORT_MIN
         private val defaultEndDate
             get() = Clock.System.nowLocal().date
+        private val defaultLastImportDate
+            get() = LocalDate(year = 2000, monthNumber = 1, dayOfMonth = 1)
 
         fun factory() = object : ViewModelProvider.Factory {
             @Suppress("UNCHECKED_CAST")
@@ -173,9 +183,7 @@ data class ViewState(
     val startDate: LocalDate,
     val endDate: LocalDate,
     val importStatus: ImportStatus = ImportStatus.NotStarted,
-    val lastImportDate: LocalDate = Instant.DISTANT_PAST
-        .toLocalDateTime(TimeZone.currentSystemDefault())
-        .date,
+    val lastImportDate: LocalDate,
     val useLastImportTime: Boolean = true,
 ) {
     val isImportEnabled: Boolean

--- a/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/utils/PrefManager.kt
+++ b/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/utils/PrefManager.kt
@@ -45,7 +45,7 @@ class PrefManager(private val keyValueStore: KeyValueStoreV2) {
         keyValueStore.putBoolean(Key.SHOW_LOGS_BUTTON, showLogsButton)
     }
 
-    fun getLastImportDate(): Flow<Instant> {
+    fun getLastImportDate(): Flow<Instant?> {
         return keyValueStore
             .getStringFlow(Key.LAST_IMPORT_DATE, "")
             .map { timeString ->
@@ -53,7 +53,6 @@ class PrefManager(private val keyValueStore: KeyValueStoreV2) {
                     ?.let {
                         runCatching { Instant.parse(it) }.getOrNull()
                     }
-                    ?: Instant.DISTANT_PAST
             }
     }
 


### PR DESCRIPTION
The default last import was too old for the date picker to work
properly. So using a different much more recent default last import
date now
