### PR TITLE
Make date picker dialog not default width

### DIFF
--- a/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/ui/components/Date.kt
+++ b/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/ui/components/Date.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
@@ -41,8 +42,13 @@ fun Date(
     onResetDateToToday: (() -> Unit)?,
     onDismiss: () -> Unit,
 ) {
-    Dialog(onDismissRequest = onDismiss) {
-        Card {
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(
+            usePlatformDefaultWidth = false
+        )
+    ) {
+        Card(modifier = Modifier.padding(16.dp)) {
             fun Long.toLocalDate(): LocalDate {
                 return Instant
                     .fromEpochMilliseconds(this)


### PR DESCRIPTION
Was resulting in date picker not being shown fully if font size was
too big. This makes it take too much width on desktop app but okay
with that for now
