### PR TITLE
Simplify date selection logic on home screen

### DIFF
--- a/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/data/EntryConflictDao.kt
+++ b/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/data/EntryConflictDao.kt
@@ -9,7 +9,10 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 abstract class EntryConflictDao {
     @Query("SELECT * FROM entryconflict")
-    abstract fun getAllFlow(): Flow<List<EntryConflict>>
+    abstract fun getFlow(): Flow<List<EntryConflict>>
+
+    @Query("SELECT COUNT(DISTINCT entry_id) FROM entryconflict WHERE entry_id IN (:entryIds)")
+    abstract suspend fun getCount(entryIds: List<String>): Int
 
     @Query("DELETE FROM entryconflict WHERE entry_id=:entryId")
     abstract suspend fun deleteForEntryId(entryId: String)

--- a/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/data/JournalEntryDao.kt
+++ b/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/data/JournalEntryDao.kt
@@ -21,6 +21,9 @@ abstract class JournalEntryDao {
     @Query("SELECT * FROM journalentry WHERE reconciled = 0 AND deleted = 0")
     abstract fun getAllFlowNotReconciled(): Flow<List<JournalEntry>>
 
+    @Query("SELECT DISTINCT entry_time FROM journalentry WHERE reconciled = 0 AND deleted = 0 ORDER BY entry_time ASC")
+    abstract fun getNotReconciledEntryTimesFlow(): Flow<List<LocalDateTime>>
+
     @Query("SELECT * FROM journalentry WHERE reconciled = 0 AND deleted = 0 ORDER BY entry_time ASC")
     abstract suspend fun getAll(): List<JournalEntry>
 

--- a/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/model/DateWithCount.kt
+++ b/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/model/DateWithCount.kt
@@ -1,0 +1,9 @@
+package com.ramitsuri.notificationjournal.core.model
+
+import kotlinx.datetime.LocalDate
+
+data class DateWithCount(
+    val date: LocalDate,
+    val conflictCount: Int,
+    val untaggedCount: Int,
+)

--- a/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/repository/JournalRepository.kt
+++ b/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/repository/JournalRepository.kt
@@ -3,6 +3,7 @@ package com.ramitsuri.notificationjournal.core.repository
 import co.touchlab.kermit.Logger
 import com.ramitsuri.notificationjournal.core.data.EntryConflictDao
 import com.ramitsuri.notificationjournal.core.data.JournalEntryDao
+import com.ramitsuri.notificationjournal.core.model.DateWithCount
 import com.ramitsuri.notificationjournal.core.model.EntryConflict
 import com.ramitsuri.notificationjournal.core.model.Tag
 import com.ramitsuri.notificationjournal.core.model.entry.JournalEntry
@@ -18,6 +19,9 @@ import com.ramitsuri.notificationjournal.core.utils.plus
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
 import kotlinx.datetime.Clock
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
@@ -39,6 +43,23 @@ class JournalRepository(
             dao.getAllFlow()
         } else {
             dao.getAllFlowNotReconciled()
+        }
+    }
+
+    fun getNotReconciledEntryDatesFlow(): Flow<List<DateWithCount>> {
+        return combine(
+            conflictDao.getFlow(),
+            // Used so that it refreshes the data
+            dao.getNotReconciledEntryTimesFlow(),
+        ) { _, entryTimes ->
+            entryTimes.map { it.date }.distinct()
+        }.map { entryDates ->
+            entryDates.map { date ->
+                val entriesForDate = getForDateFlow(date).first()
+                val conflictCount = entriesForDate.map { it.id }.let { conflictDao.getCount(it) }
+                val untaggedCount = entriesForDate.count { Tag.isNoTag(it.tag) }
+                DateWithCount(date = date, conflictCount = conflictCount, untaggedCount = untaggedCount)
+            }
         }
     }
 
@@ -170,7 +191,7 @@ class JournalRepository(
     }
 
     fun getConflicts(): Flow<List<EntryConflict>> {
-        return conflictDao.getAllFlow()
+        return conflictDao.getFlow()
     }
 
     suspend fun resolveConflict(

--- a/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/ui/journalentry/EntryScreenAction.kt
+++ b/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/ui/journalentry/EntryScreenAction.kt
@@ -1,12 +1,11 @@
 package com.ramitsuri.notificationjournal.core.ui.journalentry
 
-import com.ramitsuri.notificationjournal.core.model.DayGroup
 import kotlinx.datetime.LocalDate
 
 sealed interface EntryScreenAction {
     data class AddWithDate(val date: LocalDate? = null) : EntryScreenAction
 
-    data class ShowDayGroup(val dayGroup: DayGroup) : EntryScreenAction
+    data class ShowDayGroup(val date: LocalDate) : EntryScreenAction
 
     data object NavToSettings : EntryScreenAction
 

--- a/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/ui/journalentry/JournalEntryViewModel.kt
+++ b/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/ui/journalentry/JournalEntryViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.viewmodel.CreationExtras
 import co.touchlab.kermit.Logger
 import com.ramitsuri.notificationjournal.core.data.TagsDao
 import com.ramitsuri.notificationjournal.core.di.ServiceLocator
+import com.ramitsuri.notificationjournal.core.model.DateWithCount
 import com.ramitsuri.notificationjournal.core.model.DayGroup
 import com.ramitsuri.notificationjournal.core.model.EntryConflict
 import com.ramitsuri.notificationjournal.core.model.Tag
@@ -28,6 +29,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.stateIn
@@ -36,6 +38,8 @@ import kotlinx.coroutines.launch
 import kotlinx.datetime.Clock
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.minus
+import kotlin.math.absoluteValue
 import kotlin.reflect.KClass
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
@@ -52,7 +56,7 @@ class JournalEntryViewModel(
     private val _receivedText: MutableStateFlow<String?> = MutableStateFlow(receivedText)
     val receivedText: StateFlow<String?> = _receivedText
 
-    private val selectedIndex: MutableStateFlow<Int?> = MutableStateFlow(null)
+    private val selectedDate = MutableStateFlow<LocalDate?>(null)
 
     private val contentForCopy: MutableStateFlow<String> = MutableStateFlow("")
 
@@ -64,60 +68,51 @@ class JournalEntryViewModel(
 
     @OptIn(ExperimentalCoroutinesApi::class)
     val state: StateFlow<ViewState> =
-        prefManager.showReconciled().flatMapLatest { showReconciled ->
+        combine(
+            selectedDate,
+            repository.getNotReconciledEntryDatesFlow(),
+        ) { selectedDate, countAndDates ->
+            val today = clock.nowLocal().date
+            if (selectedDate == null) {
+                val closestDateToToday =
+                    countAndDates.minByOrNull { countAndDate ->
+                        today.minus(countAndDate.date).seconds.absoluteValue
+                    }?.date
+                this.selectedDate.update {
+                    closestDateToToday ?: countAndDates.lastOrNull()?.date
+                }
+            }
+            countAndDates to (selectedDate ?: today)
+        }.flatMapLatest { (countAndDates, selectedDate) ->
             combine(
-                selectedIndex,
                 contentForCopy,
                 snackBarType,
-                repository.getFlow(showReconciled = showReconciled),
+                repository.getForDateFlow(selectedDate),
                 repository.getForUploadCountFlow(),
                 repository.getConflicts(),
                 prefManager.showEmptyTags(),
                 prefManager.showConflictDiffInline(),
                 prefManager.showLogsButton(),
                 statsRequested,
-            ) { selectedIndex, contentForCopy, snackBarType, entries, forUploadCount, entryConflicts,
+            ) { contentForCopy, snackBarType, entries, forUploadCount, entryConflicts,
                 showEmptyTags, showConflictDiffInline, showLogsButton, statsRequested,
                 ->
                 val tags = tagsDao.getAll()
-                val dayGroups =
-                    try {
-                        entries.toDayGroups(
-                            tagsForSort = tags.map { it.value },
-                        )
-                    } catch (e: Exception) {
-                        listOf()
-                    }
-                val sorted = dayGroups.sortedBy { it.date }
-                // Show either today or the biggest date as initially selected
-                if (selectedIndex == null) {
-                    if (sorted.isNotEmpty()) {
-                        this.selectedIndex.update {
-                            sorted
-                                .indexOfFirst {
-                                    it.date == clock.nowLocal().date
-                                }
-                                .takeIf { it >= 0 }
-                                ?: sorted.lastIndex
-                        }
-                    }
-                    ViewState()
-                } else {
-                    ViewState(
-                        dayGroups = sorted,
-                        tags = tags,
-                        notUploadedCount = forUploadCount,
-                        entryConflicts = entryConflicts,
-                        showConflictDiffInline = showConflictDiffInline,
-                        selectedIndex = selectedIndex,
-                        contentForCopy = contentForCopy,
-                        showEmptyTags = showEmptyTags,
-                        snackBarType = snackBarType,
-                        showLogsButton = showLogsButton,
-                        stats = if (statsRequested) repository.getStats() else null,
-                        allowNotify = allowNotify,
-                    )
-                }
+                val entryIds = entries.map { it.id }
+                ViewState(
+                    dateWithCountList = countAndDates,
+                    dayGroup = entries.toDayGroups().firstOrNull() ?: ViewState.defaultDayGroup,
+                    tags = tags,
+                    notUploadedCount = forUploadCount,
+                    entryConflicts = entryConflicts.filter { entryIds.contains(it.entryId) },
+                    showConflictDiffInline = showConflictDiffInline,
+                    contentForCopy = contentForCopy,
+                    showEmptyTags = showEmptyTags,
+                    snackBarType = snackBarType,
+                    showLogsButton = showLogsButton,
+                    stats = if (statsRequested) repository.getStats() else null,
+                    allowNotify = allowNotify,
+                )
             }
         }.stateIn(
             scope = viewModelScope,
@@ -280,37 +275,45 @@ class JournalEntryViewModel(
     }
 
     fun goToNextDay() {
-        selectedIndex.update { existing ->
+        selectedDate.update { existing ->
+            val dateWithCountList = state.value.dateWithCountList
+            if (dateWithCountList.isEmpty()) {
+                return
+            }
             if (existing == null) {
                 return
             }
-            val new = existing + 1
-            if (new > state.value.dayGroups.lastIndex) {
-                0
+            val existingIndex = state.value.dateWithCountList.indexOfFirst { it.date == existing }
+            val newIndex = existingIndex + 1
+            if (newIndex > dateWithCountList.lastIndex) {
+                dateWithCountList.first().date
             } else {
-                new
+                dateWithCountList[newIndex].date
             }
         }
     }
 
     fun goToPreviousDay() {
-        selectedIndex.update { existing ->
+        selectedDate.update { existing ->
+            val dateWithCountList = state.value.dateWithCountList
+            if (dateWithCountList.isEmpty()) {
+                return
+            }
             if (existing == null) {
                 return
             }
-            val new = existing - 1
-            if (new < 0) {
-                state.value.dayGroups.lastIndex
+            val existingIndex = state.value.dateWithCountList.indexOfFirst { it.date == existing }
+            val newIndex = existingIndex - 1
+            if (newIndex < 0) {
+                dateWithCountList.last().date
             } else {
-                new
+                dateWithCountList[newIndex].date
             }
         }
     }
 
-    fun showDayGroupClicked(dayGroup: DayGroup) {
-        val existing = state.value
-        val index = existing.dayGroups.indexOf(dayGroup)
-        selectedIndex.update { index }
+    fun showDayGroupClicked(date: LocalDate) {
+        selectedDate.update { date }
     }
 
     fun onCopy(entry: JournalEntry) {
@@ -326,11 +329,19 @@ class JournalEntryViewModel(
     }
 
     fun onCopy() {
-        val dayGroup = state.value.selectedDayGroup
+        val conflicts = state.value.entryConflicts
+        val dayGroup = state.value.dayGroup
+        if (dayGroup == ViewState.defaultDayGroup) {
+            return
+        }
         if (dayGroup.untaggedCount > 0) {
             return
         }
-        if ((state.value.dayGroupConflictCountMap[dayGroup] ?: 0) > 0) {
+        val dayGroupEntryIds = dayGroup.tagGroups.flatMap { it.entries }.map { it.id }
+        if (dayGroupEntryIds.isEmpty()) {
+            return
+        }
+        if (conflicts.any { dayGroupEntryIds.contains(it.id) }) {
             return
         }
         viewModelScope.launch(Dispatchers.Default) {
@@ -433,12 +444,12 @@ class JournalEntryViewModel(
 }
 
 data class ViewState(
-    val dayGroups: List<DayGroup> = listOf(),
+    val dateWithCountList: List<DateWithCount> = listOf(),
+    val dayGroup: DayGroup = defaultDayGroup,
     val tags: List<Tag> = listOf(),
     val notUploadedCount: Int = 0,
     val entryConflicts: List<EntryConflict> = listOf(),
     val showConflictDiffInline: Boolean = false,
-    val selectedIndex: Int = 0,
     val contentForCopy: String = "",
     val showEmptyTags: Boolean = false,
     val showLogsButton: Boolean = false,
@@ -446,18 +457,9 @@ data class ViewState(
     val stats: EntryStats? = null,
     val allowNotify: Boolean = false,
 ) {
-    val selectedDayGroup: DayGroup
-        get() {
-            return dayGroups.getOrNull(selectedIndex) ?: DayGroup(
-                LocalDate(1970, 1, 1),
-                listOf(),
-            )
-        }
-
-    val dayGroupConflictCountMap
-        get() =
-            dayGroups
-                .associateWith { it.getConflictsCount(entryConflicts) }
+    companion object {
+        val defaultDayGroup = DayGroup(LocalDate(1970, 1, 1), listOf())
+    }
 }
 
 sealed interface SnackBarType {

--- a/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/ui/nav/Navigation.kt
+++ b/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/ui/nav/Navigation.kt
@@ -140,7 +140,7 @@ fun NavGraph(
                         }
 
                         is EntryScreenAction.ShowDayGroup -> {
-                            viewModel.showDayGroupClicked(action.dayGroup)
+                            viewModel.showDayGroupClicked(action.date)
                         }
 
                         is EntryScreenAction.ShowStatsToggled -> {

--- a/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/utils/Flows.kt
+++ b/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/utils/Flows.kt
@@ -34,6 +34,43 @@ fun <T1, T2, T3, T4, T5, T6, T7, R> combine(
     }
 
 @Suppress("UNCHECKED_CAST")
+fun <T1, T2, T3, T4, T5, T6, T7, T8, T9, R> combine(
+    flow: Flow<T1>,
+    flow2: Flow<T2>,
+    flow3: Flow<T3>,
+    flow4: Flow<T4>,
+    flow5: Flow<T5>,
+    flow6: Flow<T6>,
+    flow7: Flow<T7>,
+    flow8: Flow<T8>,
+    flow9: Flow<T9>,
+    transform: suspend (T1, T2, T3, T4, T5, T6, T7, T8, T9) -> R,
+): Flow<R> =
+    kotlinx.coroutines.flow.combine(
+        flow,
+        flow2,
+        flow3,
+        flow4,
+        flow5,
+        flow6,
+        flow7,
+        flow8,
+        flow9,
+    ) { args: Array<*> ->
+        transform(
+            args[0] as T1,
+            args[1] as T2,
+            args[2] as T3,
+            args[3] as T4,
+            args[4] as T5,
+            args[5] as T6,
+            args[6] as T7,
+            args[7] as T8,
+            args[8] as T9,
+        )
+    }
+
+@Suppress("UNCHECKED_CAST")
 fun <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R> combine(
     flow: Flow<T1>,
     flow2: Flow<T2>,

--- a/core/src/jvmTest/kotlin/com/ramitsuri/notificationjournal/core/repository/JournalRepositoryTest.kt
+++ b/core/src/jvmTest/kotlin/com/ramitsuri/notificationjournal/core/repository/JournalRepositoryTest.kt
@@ -151,7 +151,7 @@ class JournalRepositoryTest {
             assertEquals(1, entries.size)
             assertEquals("one", entries.first().text)
 
-            val conflicts = db.entryConflictDao().getAllFlow().first()
+            val conflicts = db.entryConflictDao().getFlow().first()
             assertEquals(1, conflicts.size)
             assertEquals("one-corrected", conflicts.first().text)
             assertEquals("1", conflicts.first().entryId)
@@ -178,7 +178,7 @@ class JournalRepositoryTest {
             assertEquals(1, entries.size)
             assertEquals("one", entries.first().text)
 
-            db.entryConflictDao().getAllFlow().test { expectNoEvents() }
+            db.entryConflictDao().getFlow().test { expectNoEvents() }
         }
 
     private class TestClock : Clock {


### PR DESCRIPTION
Getting just dates now rather than all of the entries for all
the dates. Also, separately getting counts for them to combine them
with dates when showing in date selection dialog
