### PR TITLE
Fix incorrect date selected on when app opens

### DIFF
--- a/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/ui/journalentry/JournalEntryViewModel.kt
+++ b/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/ui/journalentry/JournalEntryViewModel.kt
@@ -37,7 +37,7 @@ import kotlinx.coroutines.launch
 import kotlinx.datetime.Clock
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
-import kotlinx.datetime.minus
+import kotlinx.datetime.daysUntil
 import kotlin.math.absoluteValue
 import kotlin.reflect.KClass
 import kotlin.time.Duration
@@ -73,7 +73,7 @@ class JournalEntryViewModel(
             if (selectedDate == null) {
                 val closestDateToToday =
                     countAndDates.minByOrNull { countAndDate ->
-                        today.minus(countAndDate.date).days.absoluteValue
+                        countAndDate.date.daysUntil(today).absoluteValue
                     }?.date
                 this.selectedDate.update {
                     closestDateToToday ?: countAndDates.lastOrNull()?.date


### PR DESCRIPTION
On opening the app, was selecting the wrong date to show by default.
This was because I was getting the difference between days as
DatePeriod and then using the number of days in the period to
determine the closest one to today. But that only takes into account
the days irrespective of number of months in the period.

For example, following periods are considered the same in my old way
(1month, 1day), (2months, 1 day), (3months, 1day)

Fixed to use `daysUntil` which gives the expected number
