### PR TITLE
Attempt to make Rabbit Mq connection more robust

### DIFF
--- a/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/model/DataHostProperties.kt
+++ b/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/model/DataHostProperties.kt
@@ -1,5 +1,6 @@
 package com.ramitsuri.notificationjournal.core.model
 
+import com.ramitsuri.notificationjournal.core.model.sync.Sender
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -24,4 +25,11 @@ data class DataHostProperties(
         return deviceName.isNotBlank() && deviceId.isNotBlank() && exchangeName.isNotBlank() &&
             dataHost.isNotBlank() && username.isNotBlank() && password.isNotBlank()
     }
+}
+
+fun DataHostProperties.toSender(): Sender {
+    return Sender(
+        name = deviceName,
+        id = deviceId,
+    )
 }

--- a/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/network/DataReceiveHelper.kt
+++ b/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/network/DataReceiveHelper.kt
@@ -1,9 +1,8 @@
 package com.ramitsuri.notificationjournal.core.network
 
 import com.ramitsuri.notificationjournal.core.model.sync.Payload
+import kotlinx.coroutines.flow.SharedFlow
 
 interface DataReceiveHelper {
-    suspend fun startListening(onPayloadReceived: (Payload) -> Unit)
-
-    suspend fun closeConnection()
+    val payloadFlow: SharedFlow<Payload>
 }

--- a/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/network/DataReceiveHelperImpl.kt
+++ b/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/network/DataReceiveHelperImpl.kt
@@ -1,99 +1,23 @@
 package com.ramitsuri.notificationjournal.core.network
 
-import co.touchlab.kermit.Logger
-import com.rabbitmq.client.Channel
-import com.rabbitmq.client.Connection
-import com.rabbitmq.client.ConnectionFactory
-import com.rabbitmq.client.DeliverCallback
-import com.rabbitmq.client.Delivery
+import com.ramitsuri.notificationjournal.core.di.ServiceLocator
 import com.ramitsuri.notificationjournal.core.model.DataHostProperties
-import com.ramitsuri.notificationjournal.core.model.sync.Payload
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
-import kotlinx.coroutines.withContext
-import kotlinx.serialization.json.Json
+import kotlinx.coroutines.flow.SharingStarted.Companion.WhileSubscribed
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.shareIn
 
 internal class DataReceiveHelperImpl(
-    private val ioDispatcher: CoroutineDispatcher,
-    private val getDataHostProperties: suspend () -> DataHostProperties,
-    private val json: Json,
+    ioDispatcher: CoroutineDispatcher,
+    getDataHostProperties: suspend () -> DataHostProperties,
+    rabbitMqHelper: RabbitMqHelper,
 ) : DataReceiveHelper {
-    private var connection: Connection? = null
-    private var channel: Channel? = null
-    private val mutex: Mutex = Mutex()
-
-    override suspend fun startListening(onPayloadReceived: (Payload) -> Unit) {
-        log("Start receiving")
-        val dataHostProperties = getDataHostProperties()
-        if (!dataHostProperties.isValid()) {
-            log("Cannot start receiving, invalid data host properties")
-            return
-        }
-        val deliverCallback =
-            DeliverCallback { _: String?, delivery: Delivery ->
-                val message = String(delivery.body, Charsets.UTF_8)
-                val payload = json.decodeFromString<Payload>(message)
-                if (payload.sender.id == dataHostProperties.deviceId) {
-                    log("Ignoring own message")
-                    return@DeliverCallback
-                }
-                onPayloadReceived(payload)
-            }
-        withContext(ioDispatcher) {
-            mutex.withLock {
-                createChannelIfNecessary(dataHostProperties)
-                try {
-                    channel?.let {
-                        it.basicConsume(dataHostProperties.deviceName, true, deliverCallback) { _ -> }
-                    } ?: log("Channel not available")
-                } catch (e: Exception) {
-                    log("Failed to setup receiver", e)
-                }
-            }
-        }
-    }
-
-    override suspend fun closeConnection() {
-        mutex.withLock {
-            runCatching {
-                connection?.close()
-                connection = null
-                channel?.close()
-                channel = null
-            }
-        }
-    }
-
-    private suspend fun createChannelIfNecessary(dataHostProperties: DataHostProperties) {
-        try {
-            if (connection == null) {
-                connection =
-                    ConnectionFactory().apply {
-                        host = dataHostProperties.dataHost
-                        username = dataHostProperties.username
-                        password = dataHostProperties.password
-                        isAutomaticRecoveryEnabled = true
-                        isTopologyRecoveryEnabled = true
-                    }.newConnection()
-                channel = connection?.createChannel()
-                channel?.queueDeclare(dataHostProperties.deviceName, true, false, false, null)
-                channel?.queueBind(dataHostProperties.deviceName, dataHostProperties.exchangeName, "")
-            }
-        } catch (e: Exception) {
-            log("Failed to connect to RabbitMQ", e)
-            closeConnection()
-        }
-    }
-
-    private fun log(
-        message: String,
-        throwable: Throwable? = null,
-    ) {
-        Logger.i(TAG, throwable) { message }
-    }
-
-    companion object {
-        private const val TAG = "DataReceiveHelper"
-    }
+    override val payloadFlow =
+        rabbitMqHelper
+            .receive(getDataHostProperties)
+            .flowOn(ioDispatcher)
+            .shareIn(
+                scope = ServiceLocator.coroutineScope,
+                started = WhileSubscribed(),
+            )
 }

--- a/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/network/DataSendHelper.kt
+++ b/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/network/DataSendHelper.kt
@@ -16,6 +16,4 @@ interface DataSendHelper {
         days: List<LocalDate>,
         entries: List<JournalEntry>,
     ): Boolean
-
-    suspend fun closeConnection()
 }

--- a/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/network/DataSendHelperImpl.kt
+++ b/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/network/DataSendHelperImpl.kt
@@ -1,33 +1,17 @@
 package com.ramitsuri.notificationjournal.core.network
 
 import co.touchlab.kermit.Logger
-import com.rabbitmq.client.Channel
-import com.rabbitmq.client.Connection
-import com.rabbitmq.client.ConnectionFactory
-import com.rabbitmq.client.MessageProperties
 import com.ramitsuri.notificationjournal.core.model.DataHostProperties
 import com.ramitsuri.notificationjournal.core.model.Tag
 import com.ramitsuri.notificationjournal.core.model.entry.JournalEntry
 import com.ramitsuri.notificationjournal.core.model.sync.Payload
-import com.ramitsuri.notificationjournal.core.model.sync.Sender
 import com.ramitsuri.notificationjournal.core.model.template.JournalEntryTemplate
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
-import kotlinx.coroutines.withContext
 import kotlinx.datetime.LocalDate
-import kotlinx.serialization.json.Json
-import kotlin.time.Duration.Companion.seconds
 
 internal class DataSendHelperImpl(
-    private val ioDispatcher: CoroutineDispatcher,
     private val getDataHostProperties: suspend () -> DataHostProperties,
-    private val json: Json,
+    private val rabbitMqHelper: RabbitMqHelper,
 ) : DataSendHelper {
-    private var connection: Connection? = null
-    private var channel: Channel? = null
-    private val mutex: Mutex = Mutex()
-
     override suspend fun sendEntries(entries: List<JournalEntry>): Boolean {
         return Payload.Entries(
             data = entries,
@@ -56,81 +40,12 @@ internal class DataSendHelperImpl(
         ).send()
     }
 
-    private suspend fun Payload.send(isRetry: Boolean = false): Boolean {
+    private suspend fun Payload.send(): Boolean {
         log("Sending payload")
-        val dataHostProperties = getDataHostProperties()
-        if (!dataHostProperties.isValid()) {
-            log("Cannot send, invalid data host properties")
-            return false
-        }
-        val payloadWithSender =
-            this.attachSender(Sender(name = dataHostProperties.deviceName, id = dataHostProperties.deviceId))
-        return withContext(ioDispatcher) {
-            mutex.withLock {
-                createChannelIfNecessary(dataHostProperties)
-                try {
-                    val message = json.encodeToString(payloadWithSender).toByteArray()
-                    channel?.let {
-                        it.basicPublish(
-                            dataHostProperties.exchangeName,
-                            "",
-                            MessageProperties.PERSISTENT_TEXT_PLAIN,
-                            message,
-                        )
-                        it.waitForConfirmsOrDie(5.seconds.inWholeMilliseconds)
-                        true
-                    } ?: run {
-                        log("Channel not available")
-                        false
-                    }
-                } catch (e: Exception) {
-                    log("failed to send message", e)
-                    if (isRetry) {
-                        return@withContext false
-                    } else {
-                        closeConnectionInternal()
-                        return@withContext send(isRetry = true)
-                    }
-                }
-            }
-        }
-    }
-
-    override suspend fun closeConnection() {
-        log("Closing connection")
-        mutex.withLock {
-            closeConnectionInternal()
-        }
-    }
-
-    private fun closeConnectionInternal() {
-        runCatching {
-            connection?.close()
-            connection = null
-            channel?.close()
-            channel = null
-            log("Connection closed")
-        }
-    }
-
-    private fun createChannelIfNecessary(dataHostProperties: DataHostProperties) {
-        try {
-            if (connection == null) {
-                connection =
-                    ConnectionFactory().apply {
-                        host = dataHostProperties.dataHost
-                        username = dataHostProperties.username
-                        password = dataHostProperties.password
-                        isAutomaticRecoveryEnabled = true
-                        isTopologyRecoveryEnabled = true
-                    }.newConnection()
-                channel = connection?.createChannel()
-                channel?.confirmSelect()
-            }
-        } catch (e: Exception) {
-            log("Failed to connect to RabbitMQ", e)
-            closeConnectionInternal()
-        }
+        return rabbitMqHelper.send(
+            getDataHostProperties = getDataHostProperties,
+            payload = this,
+        )
     }
 
     private fun log(

--- a/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/network/RabbitMqHelper.kt
+++ b/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/network/RabbitMqHelper.kt
@@ -1,0 +1,246 @@
+package com.ramitsuri.notificationjournal.core.network
+
+import co.touchlab.kermit.Logger
+import com.rabbitmq.client.AlreadyClosedException
+import com.rabbitmq.client.Channel
+import com.rabbitmq.client.Connection
+import com.rabbitmq.client.ConnectionFactory
+import com.rabbitmq.client.MessageProperties
+import com.ramitsuri.notificationjournal.core.model.DataHostProperties
+import com.ramitsuri.notificationjournal.core.model.sync.Payload
+import com.ramitsuri.notificationjournal.core.model.toSender
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.channels.trySendBlocking
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import kotlin.time.Duration.Companion.seconds
+
+class RabbitMqHelper(
+    private val json: Json,
+    private val ioDispatcher: CoroutineDispatcher,
+) {
+    private var connection: Connection? = null
+    private val mutex: Mutex = Mutex()
+
+    suspend fun send(
+        getDataHostProperties: suspend () -> DataHostProperties,
+        payload: Payload,
+    ): Boolean {
+        val dataHostProperties = getDataHostProperties()
+        if (!dataHostProperties.isValid()) {
+            log("Cannot send, invalid data host properties")
+            return false
+        }
+        val channel = createSendChannel(dataHostProperties)
+        if (channel == null) {
+            log("Failed to create channel")
+            return false
+        }
+        return withContext(ioDispatcher) {
+            val actualPayload = payload.attachSender(dataHostProperties.toSender())
+            channel.safelyPublish(
+                dataHostProperties = dataHostProperties,
+                message = json.encodeToString(actualPayload).toByteArray(),
+            )
+        }
+    }
+
+    fun receive(getDataHostProperties: suspend () -> DataHostProperties): Flow<Payload> =
+        callbackFlow {
+            val dataHostProperties = getDataHostProperties()
+            if (!dataHostProperties.isValid()) {
+                log("Cannot start receiving, invalid data host properties")
+                return@callbackFlow
+            }
+            val channel = createReceiveChannel(dataHostProperties)
+            if (channel == null) {
+                log("Failed to create channel")
+                return@callbackFlow
+            }
+            val token =
+                try {
+                    channel.basicConsume(
+                        // queue =
+                        dataHostProperties.deviceName,
+                        // autoAck =
+                        true,
+                        // deliverCallback =
+                        { _, delivery ->
+                            val message = String(delivery.body, Charsets.UTF_8)
+                            val payload = json.decodeFromString<Payload>(message)
+                            if (payload.sender.id == dataHostProperties.deviceId) {
+                                log("Ignoring own message")
+                            } else {
+                                trySendBlocking(payload)
+                            }
+                        },
+                        // cancelCallback =
+                        {
+                            channel.close()
+                            close()
+                        },
+                    )
+                } catch (_: AlreadyClosedException) {
+                    log("Connection already closed, reset connection")
+                    this@RabbitMqHelper.close()
+                    getConnection(dataHostProperties)
+                    null
+                } catch (e: Exception) {
+                    log("Failed to setup receiver", e)
+                    null
+                }
+            awaitClose {
+                token?.let { runCatching { channel.basicCancel(it) } }
+            }
+        }
+
+    private suspend fun createReceiveChannel(dataHostProperties: DataHostProperties): Channel? {
+        return withContext(ioDispatcher) {
+            getConnection(dataHostProperties)
+                ?.safelyCreateChannel()
+                ?.apply {
+                    queueDeclare(
+                        // queue =
+                        dataHostProperties.deviceName,
+                        // durable =
+                        true,
+                        // exclusive =
+                        false,
+                        // autoDelete =
+                        false,
+                        // arguments =
+                        null,
+                    )
+                    queueBind(
+                        // queue =
+                        dataHostProperties.deviceName,
+                        // exchange =
+                        dataHostProperties.exchangeName,
+                        // routingKey =
+                        "",
+                    )
+                }
+        }
+    }
+
+    suspend fun close() {
+        mutex.withLock {
+            withContext(ioDispatcher) {
+                try {
+                    connection?.close()
+                    connection = null
+                } catch (e: Exception) {
+                    log("Failed to close connection", e)
+                }
+            }
+        }
+    }
+
+    private suspend fun createSendChannel(dataHostProperties: DataHostProperties): Channel? {
+        return withContext(ioDispatcher) {
+            getConnection(dataHostProperties)
+                ?.safelyCreateChannel()
+                ?.apply {
+                    confirmSelect()
+                }
+        }
+    }
+
+    private suspend fun getConnection(dataHostProperties: DataHostProperties): Connection? {
+        return mutex.withLock {
+            withContext(ioDispatcher) {
+                connection ?: ConnectionFactory()
+                    .apply {
+                        host = dataHostProperties.dataHost
+                        username = dataHostProperties.username
+                        password = dataHostProperties.password
+                        isAutomaticRecoveryEnabled = true
+                        isTopologyRecoveryEnabled = true
+                    }.let {
+                        try {
+                            it.newConnection()
+                        } catch (e: Exception) {
+                            log("Failed to connect to RabbitMQ", e)
+                            null
+                        }
+                    }
+                    .also { connection = it }
+            }
+        }
+    }
+
+    private suspend fun Channel.safelyPublish(
+        dataHostProperties: DataHostProperties,
+        message: ByteArray,
+        isRetry: Boolean = false,
+    ): Boolean {
+        return try {
+            basicPublish(
+                // exchange =
+                dataHostProperties.exchangeName,
+                // routingKey =
+                "",
+                // props =
+                MessageProperties.PERSISTENT_TEXT_PLAIN,
+                // body =
+                message,
+            )
+            waitForConfirmsOrDie(5.seconds.inWholeMilliseconds)
+            true
+        } catch (_: AlreadyClosedException) {
+            log("Connection already closed, reset connection")
+            this@RabbitMqHelper.close()
+            getConnection(dataHostProperties)
+            false
+        } catch (e: Exception) {
+            log("failed to publish message", e)
+            if (isRetry) {
+                false
+            } else {
+                safelyClose()
+                safelyPublish(
+                    dataHostProperties = dataHostProperties,
+                    message = message,
+                    isRetry = true,
+                )
+            }
+        } finally {
+            log("closing channel after send")
+            safelyClose()
+        }
+    }
+
+    private fun Channel.safelyClose() {
+        try {
+            close()
+        } catch (e: Exception) {
+            log("failed to close channel", e)
+        }
+    }
+
+    private suspend fun Connection.safelyCreateChannel() =
+        try {
+            withContext(ioDispatcher) {
+                createChannel()
+            }
+        } catch (e: Exception) {
+            log("Failed to create channel", e)
+            null
+        }
+
+    private fun log(
+        message: String,
+        throwable: Throwable? = null,
+    ) {
+        Logger.i(TAG, throwable) { message }
+    }
+
+    companion object {
+        private const val TAG = "RabbitMqHelper"
+    }
+}

--- a/core/src/jvmTest/kotlin/com/ramitsuri/notificationjournal/core/utils/TestDataSendHelper.kt
+++ b/core/src/jvmTest/kotlin/com/ramitsuri/notificationjournal/core/utils/TestDataSendHelper.kt
@@ -33,8 +33,4 @@ class TestDataSendHelper : DataSendHelper {
     ): Boolean {
         return sendSuccessful
     }
-
-    override suspend fun closeConnection() {
-        println("Closed")
-    }
 }


### PR DESCRIPTION
- Make the app use a single connection for both receive and send
because that's what's recommended
- Close channel after every send as they are light weight and can
be closed
- Return a shared flow of received payloads so can have multiple
listeners
