### PR TITLE
Disable upload notification action

### DIFF
--- a/app/src/main/java/com/ramitsuri/notificationjournal/MainApplication.kt
+++ b/app/src/main/java/com/ramitsuri/notificationjournal/MainApplication.kt
@@ -70,12 +70,6 @@ class MainApplication : Application(), DefaultLifecycleObserver {
                             intentReceiverClass = NotificationActionReceiver::class.java,
                             remoteInputKey = Constants.REMOTE_INPUT_JOURNAL_KEY,
                         ),
-                        NotificationActionInfo(
-                            action = Constants.ACTION_UPLOAD,
-                            text = getString(R.string.upload),
-                            intentReceiverClass = NotificationActionReceiver::class.java,
-                            remoteInputKey = null,
-                        ),
                     ),
                 actionExtras = mapOf(),
             )

--- a/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/ui/editjournal/EditJournalEntryViewModel.kt
+++ b/core/src/commonMain/kotlin/com/ramitsuri/notificationjournal/core/ui/editjournal/EditJournalEntryViewModel.kt
@@ -188,10 +188,9 @@ class EditJournalEntryViewModel(
                 delete(0, length)
                 insert(0, suggestion)
             }
-        } else
-            {
-                enableGettingSuggestions.set(false)
-            }
+        } else {
+            enableGettingSuggestions.set(false)
+        }
         _state.update { it.copy(suggestions = listOf()) }
     }
 


### PR DESCRIPTION
With how server is setup right now where clients need to be online
together to be able to share data, this isn't going to work most
times, so disabling it for now
